### PR TITLE
[feat] 회원가입,로그인 페이지 UI 구현 

### DIFF
--- a/moyobab/src/components/form/FormField.tsx
+++ b/moyobab/src/components/form/FormField.tsx
@@ -1,0 +1,21 @@
+import React from "react";
+
+interface FormFieldProps {
+  label: string;
+  htmlFor: string;
+  children: React.ReactNode;
+}
+
+export function FormField({ label, htmlFor, children }: FormFieldProps) {
+  return (
+    <div className="mb-4">
+      <label
+        htmlFor={htmlFor}
+        className="block text-sm font-medium text-gray-700 mb-1"
+      >
+        {label}
+      </label>
+      {children}
+    </div>
+  );
+}

--- a/moyobab/src/components/layout/AuthLayout.tsx
+++ b/moyobab/src/components/layout/AuthLayout.tsx
@@ -1,0 +1,20 @@
+import React from "react";
+
+export default function AuthLayout({
+  children,
+  title,
+}: {
+  children: React.ReactNode;
+  title: string;
+}) {
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-gray-50 py-12 px-4">
+      <div className="max-w-md w-full bg-white p-8 rounded-lg shadow-lg space-y-6">
+        <h2 className="text-3xl font-bold text-center text-gray-900">
+          {title}
+        </h2>
+        {children}
+      </div>
+    </div>
+  );
+}

--- a/moyobab/src/pages/LoginPage.tsx
+++ b/moyobab/src/pages/LoginPage.tsx
@@ -1,0 +1,55 @@
+import React, { useState } from "react";
+import { Link, useNavigate } from "react-router-dom";
+import AuthLayout from "../components/layout/AuthLayout";
+import { FormField } from "../components/form/FormField";
+import Button from "../components/base/Button";
+
+export default function LoginPage() {
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const navigate = useNavigate();
+
+  const onSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    // TODO: 로그인 API 호출
+    navigate("/");
+  };
+
+  return (
+    <AuthLayout title="로그인">
+      <form onSubmit={onSubmit} className="space-y-4">
+        <FormField label="이메일" htmlFor="email">
+          <input
+            id="email"
+            name="email"
+            type="email"
+            required
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            className="w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-primary"
+          />
+        </FormField>
+        <FormField label="비밀번호" htmlFor="password">
+          <input
+            id="password"
+            name="password"
+            type="password"
+            required
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            className="w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-primary"
+          />
+        </FormField>
+        <Button type="submit" variant="primary" size="md" className="w-full">
+          로그인
+        </Button>
+      </form>
+      <p className="text-sm text-center text-gray-600">
+        회원이 아니신가요?{" "}
+        <Link to="/signup" className="text-primary hover:underline">
+          회원가입
+        </Link>
+      </p>
+    </AuthLayout>
+  );
+}

--- a/moyobab/src/pages/SignupPage.tsx
+++ b/moyobab/src/pages/SignupPage.tsx
@@ -1,0 +1,68 @@
+import React, { useState } from "react";
+import { Link, useNavigate } from "react-router-dom";
+import AuthLayout from "../components/layout/AuthLayout";
+import { FormField } from "../components/form/FormField";
+import Button from "../components/base/Button";
+
+export default function SignupPage() {
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [confirm, setConfirm] = useState("");
+  const navigate = useNavigate();
+
+  const onSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (password !== confirm) {
+      alert("비밀번호가 일치하지 않습니다.");
+      return;
+    }
+    // TODO: 회원가입 API 호출
+    navigate("/");
+  };
+
+  return (
+    <AuthLayout title="회원가입">
+      <form onSubmit={onSubmit} className="space-y-4">
+        <FormField label="이메일" htmlFor="email">
+          <input
+            id="email"
+            type="email"
+            required
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            className="w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-primary"
+          />
+        </FormField>
+        <FormField label="비밀번호" htmlFor="password">
+          <input
+            id="password"
+            type="password"
+            required
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            className="w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-primary"
+          />
+        </FormField>
+        <FormField label="비밀번호 확인" htmlFor="confirm">
+          <input
+            id="confirm"
+            type="password"
+            required
+            value={confirm}
+            onChange={(e) => setConfirm(e.target.value)}
+            className="w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-primary"
+          />
+        </FormField>
+        <Button type="submit" variant="primary" size="md" className="w-full">
+          회원가입
+        </Button>
+      </form>
+      <p className="text-sm text-center text-gray-600">
+        이미 계정이 있으신가요?{" "}
+        <Link to="/login" className="text-primary hover:underline">
+          로그인
+        </Link>
+      </p>
+    </AuthLayout>
+  );
+}

--- a/moyobab/src/pages/SignupPage.tsx
+++ b/moyobab/src/pages/SignupPage.tsx
@@ -6,8 +6,13 @@ import Button from "../components/base/Button";
 
 export default function SignupPage() {
   const [email, setEmail] = useState("");
+  const [name, setName] = useState("");
+  const [nickname, setNickname] = useState("");
+  const [birth, setBirth] = useState("");
+  const [phone, setPhone] = useState("");
   const [password, setPassword] = useState("");
   const [confirm, setConfirm] = useState("");
+
   const navigate = useNavigate();
 
   const onSubmit = (e: React.FormEvent) => {
@@ -16,7 +21,17 @@ export default function SignupPage() {
       alert("비밀번호가 일치하지 않습니다.");
       return;
     }
+
     // TODO: 회원가입 API 호출
+    console.log({
+      email,
+      name,
+      nickname,
+      birth,
+      phone,
+      password,
+    });
+
     navigate("/");
   };
 
@@ -33,6 +48,53 @@ export default function SignupPage() {
             className="w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-primary"
           />
         </FormField>
+
+        <FormField label="이름" htmlFor="name">
+          <input
+            id="name"
+            type="text"
+            required
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            className="w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-primary"
+          />
+        </FormField>
+
+        <FormField label="닉네임" htmlFor="nickname">
+          <input
+            id="nickname"
+            type="text"
+            required
+            value={nickname}
+            onChange={(e) => setNickname(e.target.value)}
+            className="w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-primary"
+          />
+        </FormField>
+
+        <FormField label="생년월일" htmlFor="birth">
+          <input
+            id="birth"
+            type="date"
+            required
+            value={birth}
+            onChange={(e) => setBirth(e.target.value)}
+            className="w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-primary"
+          />
+        </FormField>
+
+        <FormField label="전화번호" htmlFor="phone">
+          <input
+            id="phone"
+            type="tel"
+            placeholder="010-1234-5678"
+            pattern="^010-\d{4}-\d{4}$"
+            required
+            value={phone}
+            onChange={(e) => setPhone(e.target.value)}
+            className="w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-primary"
+          />
+        </FormField>
+
         <FormField label="비밀번호" htmlFor="password">
           <input
             id="password"
@@ -43,6 +105,7 @@ export default function SignupPage() {
             className="w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-primary"
           />
         </FormField>
+
         <FormField label="비밀번호 확인" htmlFor="confirm">
           <input
             id="confirm"
@@ -53,11 +116,13 @@ export default function SignupPage() {
             className="w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-primary"
           />
         </FormField>
+
         <Button type="submit" variant="primary" size="md" className="w-full">
           회원가입
         </Button>
       </form>
-      <p className="text-sm text-center text-gray-600">
+
+      <p className="text-sm text-center text-gray-600 mt-4">
         이미 계정이 있으신가요?{" "}
         <Link to="/login" className="text-primary hover:underline">
           로그인

--- a/moyobab/src/router/config.tsx
+++ b/moyobab/src/router/config.tsx
@@ -3,12 +3,16 @@ import HomePage from "../pages/home/page";
 import MatchPage from "../pages/match/page";
 import GroupDetailPage from "../pages/groups/[id]/page";
 import NotFoundPage from "../pages/NotFound";
+import LoginPage from "../pages/LoginPage";
+import SignupPage from "../pages/SignupPage";
 
 const routes: RouteObject[] = [
   { path: "/", element: <HomePage /> },
   { path: "/match", element: <MatchPage /> },
   { path: "/groups/:id", element: <GroupDetailPage /> },
   { path: "*", element: <NotFoundPage /> },
+  { path: "/login", element: <LoginPage /> },
+  { path: "/signup", element: <SignupPage /> },
 ];
 
 export default routes;


### PR DESCRIPTION
## ✔️ 연관 이슈
#7 

## 📝 작업 내용
1. 회원가입 페이지 UI 구현
- 이메일, 이름, 닉네임, 생년월일, 전화번호, 비밀번호, 비밀번호 확인 필드로 구성 
- 기본적인 유효성 검사 적용 (이메일 형식, 비밀번호 일치 등)

2. 로그인 페이지 UI 구현 (→ 로그인 페이지도 함께 만들었다면 이 부분 유지)
- AuthLayout 레이아웃 컴포넌트 추가 

3. FormField 컴포넌트 작성
- 라벨/입력 필드를 일관되게 구성


## 📸 스크린샷 (선택)