### PR TITLE
[refactor] 로그인 시 헤더에 유저 닉네임으로 변경되도록 로직 추가 및 에러 해결 

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,7 +1,16 @@
 import { BrowserRouter } from "react-router-dom";
 import AppRouter from "./router";
+import { useEffect } from "react";
+import { useUserStore } from "./utils/useUserStore";
 
 export default function App() {
+  const loadUserFromStorage = useUserStore(
+    (state) => state.loadUserFromStorage
+  );
+
+  useEffect(() => {
+    loadUserFromStorage();
+  }, []);
   return (
     <BrowserRouter>
       <AppRouter />

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -1,5 +1,6 @@
 import { Link, useLocation, useNavigate } from "react-router-dom";
 import { useUserStore } from "../../utils/useUserStore";
+import { useAuth } from "../../hooks/useAuth";
 
 const navItems = [
   { label: "홈", path: "/" },
@@ -12,13 +13,15 @@ export default function Header() {
   const location = useLocation();
   const navigate = useNavigate();
   const { nickname, isLoggedIn, logout } = useUserStore();
+  const { doLogout } = useAuth();
 
   const isAuthPage = ["/login", "/signup"].includes(location.pathname);
   if (isAuthPage) return null;
 
   const isActive = (path: string) => location.pathname === path;
 
-  const handleLogout = () => {
+  const handleLogout = async () => {
+    await doLogout();
     logout();
     navigate("/login");
   };

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -1,4 +1,5 @@
-import { Link, useLocation } from "react-router-dom";
+import { Link, useLocation, useNavigate } from "react-router-dom";
+import { useUserStore } from "../../utils/useUserStore";
 
 const navItems = [
   { label: "홈", path: "/" },
@@ -9,10 +10,18 @@ const navItems = [
 
 export default function Header() {
   const location = useLocation();
+  const navigate = useNavigate();
+  const { nickname, isLoggedIn, logout } = useUserStore();
+
   const isAuthPage = ["/login", "/signup"].includes(location.pathname);
   if (isAuthPage) return null;
 
   const isActive = (path: string) => location.pathname === path;
+
+  const handleLogout = () => {
+    logout();
+    navigate("/login");
+  };
 
   return (
     <header className="bg-white border-b border-gray-200 sticky top-0 z-50 shadow-sm">
@@ -39,18 +48,32 @@ export default function Header() {
         </nav>
 
         <div className="hidden sm:flex space-x-4">
-          <Link
-            to="/login"
-            className="text-gray-600 hover:text-primary transition-colors"
-          >
-            로그인
-          </Link>
-          <Link
-            to="/signup"
-            className="text-gray-600 hover:text-primary transition-colors"
-          >
-            회원가입
-          </Link>
+          {isLoggedIn ? (
+            <>
+              <span className="text-gray-700 font-medium">{nickname}님</span>
+              <button
+                onClick={handleLogout}
+                className="text-gray-600 hover:text-primary transition-colors"
+              >
+                로그아웃
+              </button>
+            </>
+          ) : (
+            <>
+              <Link
+                to="/login"
+                className="text-gray-600 hover:text-primary transition-colors"
+              >
+                로그인
+              </Link>
+              <Link
+                to="/signup"
+                className="text-gray-600 hover:text-primary transition-colors"
+              >
+                회원가입
+              </Link>
+            </>
+          )}
         </div>
       </div>
     </header>

--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -28,8 +28,12 @@ export function useAuth() {
   };
 
   const doLogout = async () => {
-    await apiLogout();
-    setIsAuthenticated(false);
+    try {
+      await apiLogout();
+    } finally {
+      clearTokens();
+      setIsAuthenticated(false);
+    }
   };
 
   return { isAuthenticated, loading, doLogin, doLogout };

--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -22,9 +22,13 @@ export function useAuth() {
     password: string,
     loginType = LoginType.BASIC
   ) => {
-    const tokens = await login(email, password, loginType);
+    const { accessToken, refreshToken, nickname } = await login(
+      email,
+      password,
+      loginType
+    );
     setIsAuthenticated(true);
-    return tokens;
+    return { accessToken, refreshToken, nickname };
   };
 
   const doLogout = async () => {

--- a/src/pages/LoginPage.tsx
+++ b/src/pages/LoginPage.tsx
@@ -3,27 +3,29 @@ import { Link, useNavigate } from "react-router-dom";
 import AuthLayout from "../components/layout/AuthLayout";
 import { FormField } from "../components/form/FormField";
 import Button from "../components/base/Button";
-import { login } from "../services/auth";
 import { LoginType } from "../types/auth";
+import { useAuth } from "../hooks/useAuth";
 
 export default function LoginPage() {
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
   const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState<boolean>(false);
   const navigate = useNavigate();
+  const { doLogin } = useAuth();
 
   const onSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
+    if (loading) return;
+    setError(null);
+    setLoading(true);
     try {
-      setError(null);
-      const tokens = await login(email, password, LoginType.BASIC);
+      await doLogin(email, password, LoginType.BASIC);
       navigate("/");
     } catch (err: any) {
-      if (err.response) {
-        setError(err.response.data.message || "로그인 실패");
-      } else {
-        setError("로그인 중 오류 발생");
-      }
+      setError(err.message || "로그인 실패");
+    } finally {
+      setLoading(false);
     }
   };
 
@@ -52,9 +54,18 @@ export default function LoginPage() {
             className="w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-primary"
           />
         </FormField>
-        <Button type="submit" variant="primary" size="md" className="w-full">
-          로그인
+        <Button
+          type="submit"
+          variant="primary"
+          size="md"
+          className="w-full"
+          disabled={loading}
+        >
+          {loading ? "로그인 중..." : "로그인"}
         </Button>
+        {error && (
+          <p className="mt-2 text-sm text-danger text-center">{error}</p>
+        )}
       </form>
       <p className="text-sm text-center text-gray-600">
         회원이 아니신가요?{" "}

--- a/src/pages/LoginPage.tsx
+++ b/src/pages/LoginPage.tsx
@@ -21,8 +21,8 @@ export default function LoginPage() {
     setError(null);
     setLoading(true);
     try {
-      const response = await doLogin(email, password, LoginType.BASIC);
-      useUserStore.getState().setUser(response.nickname);
+      const { nickname } = await doLogin(email, password, LoginType.BASIC);
+      useUserStore.getState().setUser(nickname);
       navigate("/");
     } catch (err: any) {
       setError(err.message || "로그인 실패");

--- a/src/pages/LoginPage.tsx
+++ b/src/pages/LoginPage.tsx
@@ -5,6 +5,7 @@ import { FormField } from "../components/form/FormField";
 import Button from "../components/base/Button";
 import { LoginType } from "../types/auth";
 import { useAuth } from "../hooks/useAuth";
+import { useUserStore } from "../utils/useUserStore";
 
 export default function LoginPage() {
   const [email, setEmail] = useState("");
@@ -20,7 +21,8 @@ export default function LoginPage() {
     setError(null);
     setLoading(true);
     try {
-      await doLogin(email, password, LoginType.BASIC);
+      const response = await doLogin(email, password, LoginType.BASIC);
+      useUserStore.getState().setUser(response.nickname);
       navigate("/");
     } catch (err: any) {
       setError(err.message || "로그인 실패");

--- a/src/pages/SignupPage.tsx
+++ b/src/pages/SignupPage.tsx
@@ -290,7 +290,11 @@ export default function SignupPage() {
           type="submit"
           variant="primary"
           size="md"
-          className="w-full"
+          className={`w-full transition-colors ${
+            !isValid || isSubmitting
+              ? "bg-blue-200 text-white cursor-not-allowed"
+              : "bg-blue-500 hover:bg-blue-600 text-white"
+          }`}
           disabled={!isValid || isSubmitting}
         >
           {isSubmitting ? "가입 중..." : "회원가입"}

--- a/src/pages/SignupPage.tsx
+++ b/src/pages/SignupPage.tsx
@@ -105,6 +105,7 @@ export default function SignupPage() {
     debounce(async (value: string) => {
       try {
         const res = await checkNicknameAvailable(value);
+
         if (!res.available) {
           setError("nickname", {
             type: "manual",
@@ -136,7 +137,7 @@ export default function SignupPage() {
   }, [emailValue]);
 
   useEffect(() => {
-    if (nicknameValue && !errors.nickname) {
+    if (nicknameValue) {
       debouncedCheckNickname(nicknameValue);
     }
     return () => {

--- a/src/services/auth.ts
+++ b/src/services/auth.ts
@@ -21,6 +21,7 @@ type ApiResponse<T> = {
 type AuthTokens = {
   accessToken: string;
   refreshToken: string;
+  nickname: string;
 };
 
 const apiClient = axios.create({

--- a/src/utils/tokenStorage.ts
+++ b/src/utils/tokenStorage.ts
@@ -1,20 +1,34 @@
 const ACCESS_TOKEN_KEY = "access_token";
 const REFRESH_TOKEN_KEY = "refresh_token";
 
+function safeStorage(): Storage | null {
+  try {
+    if (typeof window !== "undefined" && window.localStorage)
+      return window.localStorage;
+  } catch {}
+  return null;
+}
+
 export function saveTokens(accessToken: string, refreshToken: string) {
-  localStorage.setItem(ACCESS_TOKEN_KEY, accessToken);
-  localStorage.setItem(REFRESH_TOKEN_KEY, refreshToken);
+  const ls = safeStorage();
+  if (!ls) return;
+  ls.setItem(ACCESS_TOKEN_KEY, accessToken);
+  ls.setItem(REFRESH_TOKEN_KEY, refreshToken);
 }
 
 export function getAccessToken(): string | null {
-  return localStorage.getItem(ACCESS_TOKEN_KEY);
+  const ls = safeStorage();
+  return ls ? ls.getItem(ACCESS_TOKEN_KEY) : null;
 }
 
 export function getRefreshToken(): string | null {
-  return localStorage.getItem(REFRESH_TOKEN_KEY);
+  const ls = safeStorage();
+  return ls ? ls.getItem(REFRESH_TOKEN_KEY) : null;
 }
 
 export function clearTokens() {
-  localStorage.removeItem(ACCESS_TOKEN_KEY);
-  localStorage.removeItem(REFRESH_TOKEN_KEY);
+  const ls = safeStorage();
+  if (!ls) return;
+  ls.removeItem(ACCESS_TOKEN_KEY);
+  ls.removeItem(REFRESH_TOKEN_KEY);
 }

--- a/src/utils/useUserStore.ts
+++ b/src/utils/useUserStore.ts
@@ -1,0 +1,31 @@
+import { create } from "zustand";
+
+interface UserState {
+  nickname: string;
+  isLoggedIn: boolean;
+  setUser: (nickname: string) => void;
+  logout: () => void;
+  loadUserFromStorage: () => void;
+}
+
+export const useUserStore = create<UserState>((set) => ({
+  nickname: "",
+  isLoggedIn: false,
+
+  setUser: (nickname) => {
+    localStorage.setItem("nickname", nickname);
+    set({ nickname, isLoggedIn: true });
+  },
+
+  logout: () => {
+    localStorage.removeItem("nickname");
+    set({ nickname: "", isLoggedIn: false });
+  },
+
+  loadUserFromStorage: () => {
+    const nickname = localStorage.getItem("nickname");
+    if (nickname) {
+      set({ nickname, isLoggedIn: true });
+    }
+  },
+}));


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #11 

## 📝 작업 내용

1. 로그인 해도 헤더쪽에 로그인,회원가입으로 되어있던거 -> 로그인 하면 유저닉네임"님",로그아웃 으로 변경
2. 리팩토링 필요한 부분 (예외처리,중복 제출,에러 표시) 등 리팩토링 
3. 로컬스토리지에 유저 닉네임 저장하는 로직 추가

## 🖼️ 스크린샷 (선택)
### 닉네임도 저장하여 헤더에서 로그인하면 닉네임으로 보여지게 구현
<img width="1195" height="351" alt="화면 캡처 2025-09-15 182020" src="https://github.com/user-attachments/assets/7eb8e175-e796-4d24-86a8-53bdccd84e49" />


## 💬 리뷰 요구사항 (선택)

> X


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - 앱 시작 시 저장된 사용자 정보를 불러와 로그인 상태를 유지합니다.
  - 헤더에 추가된 메뉴 항목과 로그인 상태에 따른 닉네임 표시 및 로그아웃/로그인·회원가입 링크를 제공합니다.
  - 로그인 성공 시 닉네임을 저장하고 홈으로 이동합니다.
- Bug Fixes
  - 로그아웃 실패 시에도 토큰과 상태가 항상 정리되도록 개선했습니다.
  - 일부 환경에서의 저장소 접근 오류를 방지했습니다.
  - 중복 제출을 방지하도록 로그인 제출 로직을 보호하고 오류 메시지 처리를 단순화했습니다.
- Style
  - 로그인 버튼에 로딩 표시·비활성화 및 라벨 변경을 추가했습니다.
  - 회원가입 제출 버튼의 색상 전환 및 비활성화 스타일을 개선했습니다.
  - 닉네임 중복 확인 반응성을 향상했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->